### PR TITLE
Fixed link in Registration form

### DIFF
--- a/docker.compose.yaml
+++ b/docker.compose.yaml
@@ -3,7 +3,7 @@ services:
     database:
         image: postgres
         environment:
-            POSTGRES_USER: ${POSTGRES_USER}
+            POSTGRES_USER: ${DATABASE_USER}
             POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
             POSTGRES_DB: ${DATABASE_NAME}
         ports:

--- a/src/features/Auth/ui/RegistrationForm/index.tsx
+++ b/src/features/Auth/ui/RegistrationForm/index.tsx
@@ -26,7 +26,7 @@ export const RegistrationForm = () => {
             </CardContent>
             <CardFooter className="flex-col gap-2">
                 <Button className="w-full" text={'Create account'} disabled />
-                <Anchor href={'/'} className="w-full text-white" variant={'link'} text={'Go to Login'} />
+                <Anchor href={'/login'} className="w-full text-white" variant={'link'} text={'Go to Login'} />
             </CardFooter>
         </>
     )


### PR DESCRIPTION
RegistrationForm component to redirect to '/login' instead of the home page.

Update database environment variable and fix registration form link

- Changed the environment variable for PostgreSQL user from POSTGRES_USER to DATABASE_USER in docker.compose.yaml.